### PR TITLE
Introduce FlutterStreamsChannel to allow multiple anchoredObjectQueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.1] - 12.03.2021
+
+* Anchored Query fix with deleted objects
+
 ## [1.1.0] - 25.02.2021
 
 * iOS 9.0 support

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Flutter wrapper for [HealthKitReporter](https://cocoapods.org/pods/HealthKitRe
 - Add this to your package's pubspec.yaml file: 
 ``` Dart
 dependencies:
-     health_kit_reporter: ^1.1.0
+     health_kit_reporter: ^1.1.1
 ```
 - Get dependencies
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/health_kit_reporter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   health_kit_reporter: 4f07356cf70fff8d50b92b76ee9beacf7e3d70f9
   HealthKitReporter: 1bd60f53111044cc3a0d575d57dc4b23767c8ac6

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final _flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
   final _predicate = Predicate(
-    DateTime.now().add(Duration(days: -1)),
+    DateTime.now().add(Duration(days: -365)),
     DateTime.now(),
   );
   final _device = Device(
@@ -134,47 +134,47 @@ class _MyAppState extends State<MyApp> {
                       Column(
                         children: [
                           Text('READ'),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 handleQuantitiySamples();
                               },
                               child: Text('preferredUnit:quantity:statistics')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 queryCharacteristics();
                               },
                               child: Text('characteristics')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 queryCategory();
                               },
                               child: Text('categories')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 queryWorkout();
                               },
                               child: Text('workouts')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 querySamples();
                               },
                               child: Text('samples')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 querySources();
                               },
                               child: Text('sources')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 queryCorrelations();
                               },
                               child: Text('correlations')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 queryElectrocardiograms();
                               },
                               child: Text('electrocardiograms')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 queryActivitySummary();
                               },
@@ -184,19 +184,19 @@ class _MyAppState extends State<MyApp> {
                       Column(
                         children: [
                           Text('WRITE'),
-                          RaisedButton(
+                          ElevatedButton(
                             onPressed: () {
                               saveWorkout();
                             },
                             child: Text('saveWorkout'),
                           ),
-                          RaisedButton(
+                          ElevatedButton(
                             onPressed: () {
                               saveSteps();
                             },
                             child: Text('saveSteps'),
                           ),
-                          RaisedButton(
+                          ElevatedButton(
                             onPressed: () {
                               saveMindfulMinutes();
                             },
@@ -207,32 +207,32 @@ class _MyAppState extends State<MyApp> {
                       Column(
                         children: [
                           Text('OBSERVE'),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 observerQuery();
                               },
                               child: Text('observerQuery')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 anchoredObjectQuery();
                               },
                               child: Text('anchoredObjectQuery')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 queryActivitySummaryUpdates();
                               },
                               child: Text('queryActivitySummaryUpdates')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 statisticsCollectionQuery();
                               },
                               child: Text('statisticsCollectionQuery')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 heartbeatSeriesQuery();
                               },
                               child: Text('heartbeatSeriesQuery')),
-                          RaisedButton(
+                          ElevatedButton(
                               onPressed: () {
                                 workoutRouteQuery();
                               },
@@ -502,9 +502,10 @@ class _MyAppState extends State<MyApp> {
   void anchoredObjectQuery() {
     final identifier = QuantityType.stepCount.identifier;
     final sub = HealthKitReporter.anchoredObjectQuery(identifier, _predicate,
-        onUpdate: (samples) {
+        onUpdate: (samples, deletedObjects) {
       print('Updates for anchoredObjectQuerySub');
       print(samples.map((e) => e.map).toList());
+      print(deletedObjects.map((e) => e.map).toList());
     });
     print('anchoredObjectQuerySub: $sub');
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,56 +7,56 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -68,14 +68,14 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "5.0.0-nullsafety.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0+1"
+    version: "3.0.0-nullsafety.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -94,35 +94,35 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -141,63 +141,63 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   timezone:
     dependency: transitive
     description:
       name: timezone
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.9"
+    version: "0.7.0-nullsafety.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_local_notifications: ^3.0.2
+  flutter_local_notifications: ^5.0.0-nullsafety.0
   health_kit_reporter:
     # When depending on this package from a real application you should use:
     #   health_kit_reporter: ^x.y.z
@@ -30,7 +30,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.0
+  cupertino_icons: ^1.0.2
 
 dev_dependencies:
   flutter_test:

--- a/ios/Classes/AnchoredObjectQueryStreamHandler.swift
+++ b/ios/Classes/AnchoredObjectQueryStreamHandler.swift
@@ -42,17 +42,26 @@ extension AnchoredObjectQueryStreamHandler: StreamHandlerProtocol {
                 return
             }
             var jsonDictionary: [String: Any] = [:]
-            var jsonArray: [String] = []
+            var samplesArray: [String] = []
             for sample in samples {
                 do {
                     let encoded = try sample.encoded()
-                    jsonArray.append(encoded)
+                    samplesArray.append(encoded)
                 } catch {
                     continue
                 }
             }
-            jsonDictionary["samples"] = jsonArray
-            jsonDictionary["deletedObjects"] = try? deletedObjects.encoded()
+            var deletedObjectsArray: [String] = []
+            for deletedObject in deletedObjects {
+                do {
+                    let encoded = try deletedObject.encoded()
+                    deletedObjectsArray.append(encoded)
+                } catch {
+                    continue
+                }
+            }
+            jsonDictionary["samples"] = samplesArray
+            jsonDictionary["deletedObjects"] = deletedObjectsArray
             events(jsonDictionary)
         }
     }

--- a/ios/Classes/SwiftHealthKitReporterPlugin.swift
+++ b/ios/Classes/SwiftHealthKitReporterPlugin.swift
@@ -1,5 +1,6 @@
 import Flutter
 import HealthKitReporter
+import streams_channel
 
 public class SwiftHealthKitReporterPlugin: NSObject, FlutterPlugin {
     private enum Method: String {
@@ -61,12 +62,11 @@ public class SwiftHealthKitReporterPlugin: NSObject, FlutterPlugin {
                     let queryActivitySummaryStreamHandler = QueryActivitySummaryStreamHandler(reporter: reporter)
                     queryActivitySummaryEventChannel.setStreamHandler(queryActivitySummaryStreamHandler)
                 }
-                let anchoredObjectQueryEventChannel = FlutterEventChannel(
+                let anchoredObjectQueryEventChannel = FlutterStreamsChannel(
                     name: "health_kit_reporter_event_channel_anchored_object_query",
                     binaryMessenger: binaryMessenger
                 )
-                let anchoredObjectQueryStreamHandler = AnchoredObjectQueryStreamHandler(reporter: reporter)
-                anchoredObjectQueryEventChannel.setStreamHandler(anchoredObjectQueryStreamHandler)
+                anchoredObjectQueryEventChannel.setStreamHandlerFactory { _ in AnchoredObjectQueryStreamHandler(reporter: reporter) }
                 let heartbeatSeriesQueryEventChannel = FlutterEventChannel(
                     name: "health_kit_reporter_event_channel_heartbeat_series_query",
                     binaryMessenger: binaryMessenger

--- a/ios/health_kit_reporter.podspec
+++ b/ios/health_kit_reporter.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Flutter'
   s.dependency 'HealthKitReporter'
+  s.dependency 'streams_channel'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/health_kit_reporter.podspec
+++ b/ios/health_kit_reporter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name                  = 'health_kit_reporter'
-  s.version               = '1.1.0'
+  s.version               = '1.1.1'
   s.summary               = 'HealthKitReporter. A wrapper for HealthKit framework. A Flutter plugin'
   s.swift_versions        = '5.3'
   s.description           = 'Helps to write or read data from Apple Health via HealthKit framework using Flutter.'

--- a/lib/health_kit_reporter.dart
+++ b/lib/health_kit_reporter.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
@@ -8,6 +9,7 @@ import 'model/payload/category.dart';
 import 'model/payload/characteristic/characteristic.dart';
 import 'model/payload/correlation.dart';
 import 'model/payload/date_components.dart';
+import 'model/payload/deleted_object.dart';
 import 'model/payload/device.dart';
 import 'model/payload/electrocardiogram.dart';
 import 'model/payload/heartbeat_serie.dart';
@@ -209,7 +211,7 @@ class HealthKitReporter {
   ///
   static StreamSubscription<dynamic> anchoredObjectQuery(
       String identifier, Predicate predicate,
-      {Function(List<Sample>) onUpdate}) {
+      {Function(List<Sample>, List<DeletedObject>) onUpdate}) {
     final arguments = <String, dynamic>{
       'identifier': identifier,
     };
@@ -217,14 +219,22 @@ class HealthKitReporter {
     return _anchoredObjectQueryChannel
         .receiveBroadcastStream(arguments)
         .listen((event) {
-      final list = List.from(event);
+      final map = LinkedHashMap<String, dynamic>.from(event);
+      final samplesList = List.from(map['samples']);
       final samples = <Sample>[];
-      for (final String element in list) {
+      for (final String element in samplesList) {
         final json = jsonDecode(element);
         final sample = Sample.factory(json);
         samples.add(sample);
       }
-      onUpdate(samples);
+      final deletedObjectsList = List.from(map['deletedObjects']);
+      final deletedObjects = <DeletedObject>[];
+      for (final String element in deletedObjectsList) {
+        final json = jsonDecode(element);
+        final deletedObject = DeletedObject.fromJson(json);
+        deletedObjects.add(deletedObject);
+      }
+      onUpdate(samples, deletedObjects);
     });
   }
 

--- a/lib/health_kit_reporter.dart
+++ b/lib/health_kit_reporter.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
+import 'package:streams_channel/streams_channel.dart';
 
 import 'model/payload/activity_summary.dart';
 import 'model/payload/category.dart';
@@ -131,8 +132,8 @@ class HealthKitReporter {
   /// [EventChannel] link to [SwiftHealthKitReporterPlugin.swift]
   /// Will handle event exchanges of the plugin.
   ///
-  static const EventChannel _anchoredObjectQueryChannel =
-      EventChannel('health_kit_reporter_event_channel_anchored_object_query');
+  static final StreamsChannel _anchoredObjectQueryChannel =
+      StreamsChannel('health_kit_reporter_event_channel_anchored_object_query');
 
   /// [EventChannel] link to [SwiftHealthKitReporterPlugin.swift]
   /// Will handle event exchanges of the plugin.

--- a/lib/model/payload/deleted_object.dart
+++ b/lib/model/payload/deleted_object.dart
@@ -1,0 +1,27 @@
+/// Equivalent of [DeletedObject]
+/// from [HealthKitReporter] https://cocoapods.org/pods/HealthKitReporter
+///
+/// Supports [map] representation.
+///
+/// Has a [DeletedObject.fromJson] constructor
+/// to create instances from JSON payload coming from iOS native code.
+///
+class DeletedObject {
+  const DeletedObject(this.uuid, this.metadata);
+
+  final String uuid;
+  final Map<String, dynamic> metadata;
+
+  /// General map representation
+  ///
+  Map<String, dynamic> get map => {
+        'uuid': uuid,
+        'metadata': metadata,
+      };
+
+  /// General constructor from JSON payload
+  ///
+  DeletedObject.fromJson(Map<String, dynamic> json)
+      : uuid = json['uuid'],
+        metadata = json['metadata'];
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,35 +66,35 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,56 +106,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -121,6 +121,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  streams_channel:
+    dependency: "direct main"
+    description:
+      name: streams_channel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health_kit_reporter
 description: Helps to write or read data from Apple Health via HealthKit framework.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/VictorKachalov/health_kit_reporter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.17.0
+  streams_channel: 0.3.0
 
 dev_dependencies:
   pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.16.1
+  intl: ^0.17.0
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  pedantic: ^1.11.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
Fixes https://github.com/VictorKachalov/health_kit_reporter/issues/20 by introducing https://pub.dev/packages/streams_channel to handle multiple streams over the `health_kit_reporter_event_channel_anchored_object_query` channel.

## Notes
This issue likely affects all of the channels registered using `FlutterEventChannel`. If you're happy with the approach you can just swap in `FlutterStreamsChannel` for each `FlutterEventChannel`.