### PR TITLE
Update workout_configuration.dart

### DIFF
--- a/lib/model/payload/workout_configuration.dart
+++ b/lib/model/payload/workout_configuration.dart
@@ -20,7 +20,8 @@ class WorkoutConfiguration {
         'activityValue': activityValue,
         'locationValue': locationValue,
         'swimmingValue': swimmingValue,
-        'harmonized': harmonized.map,
+        'value': harmonized.value,
+        'unit': harmonized.unit,
       };
 }
 


### PR DESCRIPTION
## Description
This update should fix a startWatchApp problem as it currently always throws:

       HealthKitError.invalidValue(
                "Invalid dictionary: \(dictionary)"
            )

I could not fully test it, as on emulator another error is thrown "Unable to launch watch app", which in my opinion should be okay.


## Status
READY

## Migrations
NO