### PR TITLE
 Make `averageHeartRate` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.0] - 23.06.2022.
+
+* Make `averageHeartRate` optional as a `HKElectrocardiogram.Classification.inconclusivePoorReading` may not have a value for this field
+
 ## [2.0.4] - 27.05.2022
 
 * Add Correlation samples writing

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.4"
   matcher:
     dependency: transitive
     description:

--- a/lib/model/payload/electrocardiogram.dart
+++ b/lib/model/payload/electrocardiogram.dart
@@ -79,7 +79,7 @@ class ElectrocardiogramHarmonized {
     this.metadata,
   );
 
-  final num averageHeartRate;
+  final num? averageHeartRate;
   final String averageHeartRateUnit;
   final num samplingFrequency;
   final String samplingFrequencyUnit;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health_kit_reporter
 description: Helps to write or read data from Apple Health via HealthKit framework.
-version: 2.0.4
+version: 2.1.0
 homepage: https://github.com/VictorKachalov/health_kit_reporter
 
 environment:


### PR DESCRIPTION
## Status
READY

## Description
There is no option to collect the voltage measurements for electrograms with inconclusive poor readings because they do not have any value for `averageHeartRate`. Therefore, we should allow for `null` value for `averageHeartRate`.
