### PR TITLE
Get workout routes for workout UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.0] - 14.11.2024
+
+* Add getting workout routes for workout UUID
+
 ## [2.2.0] - 01.08.2024
 
 * Add support for Clinical Reports

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -236,6 +236,11 @@ class _ReadView extends StatelessWidget with HealthKitReporterMixin {
             child: Text('workoutRouteQuery')),
         TextButton(
             onPressed: () {
+              workoutRouteForUUIDQuery();
+            },
+            child: Text('workoutRouteForUUIDQuery')),
+        TextButton(
+            onPressed: () {
               querySources();
             },
             child: Text('sources')),
@@ -338,6 +343,17 @@ class _ReadView extends StatelessWidget with HealthKitReporterMixin {
   void workoutRouteQuery() async {
     try {
       final series = await HealthKitReporter.workoutRouteQuery(predicate);
+      print('workoutRoutes: ${series.map((e) => e.map).toList()}');
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  void workoutRouteForUUIDQuery() async {
+    try {
+      final series = await HealthKitReporter.workoutRouteForUUIDQuery(
+        const UUIDPredicate('D3A3D3A3-4D3A-4A3A-8A3A-3A3A3A3A3A3A'),
+      );
       print('workoutRoutes: ${series.map((e) => e.map).toList()}');
     } catch (e) {
       print(e);

--- a/lib/health_kit_reporter.dart
+++ b/lib/health_kit_reporter.dart
@@ -354,6 +354,27 @@ class HealthKitReporter {
     return routes;
   }
 
+  /// Returns [WorkoutRoute] sample for the provided UUID [predicate].
+  ///
+  /// Available only for iOS 13.0 and higher.
+  ///
+  static Future<List<WorkoutRoute>> workoutRouteForUUIDQuery(
+    UUIDPredicate predicate,
+  ) async {
+    final arguments = predicate.map;
+    final result = await _methodChannel.invokeMethod(
+      'workoutRouteForUUIDQuery',
+      arguments,
+    );
+    final List<dynamic> list = jsonDecode(result);
+    final routes = <WorkoutRoute>[];
+    for (final Map<String, dynamic> map in list) {
+      final sample = WorkoutRoute.fromJson(map);
+      routes.add(sample);
+    }
+    return routes;
+  }
+
   /// Returns [Quantity] samples for the provided [type],
   /// the preferred [unit] and the time interval predicate [predicate].
   ///

--- a/lib/model/predicate.dart
+++ b/lib/model/predicate.dart
@@ -9,6 +9,8 @@ import 'package:health_kit_reporter/health_kit_reporter.dart';
 /// For native calls the instance will be mapped to [map]
 /// and timestamps values will be accepted as arguments.
 ///
+/// See also: [UUIDPredicate]
+///
 class Predicate {
   const Predicate(
     this.startDate,
@@ -23,5 +25,29 @@ class Predicate {
   Map<String, int> get map => {
         'startTimestamp': startDate.millisecondsSinceEpoch,
         'endTimestamp': endDate.millisecondsSinceEpoch,
+      };
+}
+
+/// A predicate used in [HealthKitReporter.workoutRouteForUUIDQuery]
+/// to filter workout routes associated with the given workout UUID.
+///
+/// [uuid] - the unique identifier of the workout
+///
+/// For native calls the instance will be mapped to [map]
+/// and accepted as `arguments`.
+///
+/// See also: [Predicate]
+///
+class UUIDPredicate {
+  const UUIDPredicate(
+    this.uuid,
+  );
+
+  final String uuid;
+
+  /// General map representation
+  ///
+  Map<String, String> get map => {
+        'uuid': uuid,
       };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health_kit_reporter
 description: Helps to write or read data from Apple Health via HealthKit framework.
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/VictorKachalov/health_kit_reporter
 
 environment:


### PR DESCRIPTION
Issue: https://github.com/kvs-coder/health_kit_reporter/issues/78

## Status
READY

## Migrations
NO

## Description
Getting workout routes with time interval Predicate starting and ending at the time of the workout doesn't explicitly return routes of this workout. We get some (or no) routes without any information in them to which workout they belong to.

Trying to get routes by providng the workout UUID returns the desired routes for each workout.

I've considered extending the current `Predicate` object and `workoutRouteQuery` function to take UUID as an additional argument, but it caused a lot of issues:
- It would be hard to do it in the way that projects which are currently using the package wouldn't be affected
- Passing UUID to the `Predicate` should mean that start and end date shouldn't be provided and vice versa (needed migration)
- I've started with creating a new `Predicate` for `workoutRouteQuery`, that would either take start and end time or UUID. I've changed the map to return `Map<String, dynamic> `and swift code to take `[String, Any]` arguments map, but trying to parse arguments in `workoutRouteQuery` failed when any of the parameters was null. Using `Map<String, String>` and fallbacking to an empty string when any of the parameters was null didn't help, as parsing failed when trying to parse timestamps (and although it could be checked and avoided, I think it's a pretty nasty way of doing it)

Looking from another angle, when I passed the UUID to `workoutRouteQuery`, I  couldn't get it to work using
```
HKQuery.predicateForObject(with: uuid)
```
or any other variations of this method I've found when reserching the topic.

The solution I've seen the most is getting routes by providing a predicate from the workout itself. This is tricky in the current codebase, because I'd need concurrency to get the workout asynchronously, then get its routes and return them. This is available in iOS 13 and forcing projects already using `workoutRouteQuery` to update the iOS version is a very bad idea.

All of these reasons led me to my final decision: creating a new seperate function for getting routes by providing the workout UUID: `workoutRouteForUUIDQuery` with new `UUIDPredicate`.

This way, previous versions won't be affected and we'd get a new feature, available from iOS 13.

## Related PRs
Not applicable.

## Deploy Notes
Not applicable.

## Steps to Test or Reproduce
git pull --prune
git checkout get-workout-routes-for-workout-uuid

Run example app - there is a new text button `workoutRouteForUUIDQuery` that gets workout routes for a provided UUID in `workoutRouteForUUIDQuery` method. I've added this to test whether the native connection works. Bear in mind that this package does not provide a way to save workout routes and it's tricky to provide any test data on iOS simulator, so this method will most likely return an empty list. 

I've also noticed that although we pass the workout UUID when saving it, it gets its own UUID later on, so setting a valid UUID in `saveWorkout` method and then trying to get it in `workoutRouteForUUIDQuery` won't work, as the UUID will be changed.

## Impacted Areas in Application

- New method `workoutRouteForUUIDQuery` and new `UUIDPredicate`
- Example app now targets iOS 13

## List general components of the application that this PR will affect:

- HealthKitReporter (new method)
- Example app